### PR TITLE
feat(docs): added Let's Encrypt guide (DNS challenge)

### DIFF
--- a/app/partials/header.jade
+++ b/app/partials/header.jade
@@ -37,6 +37,8 @@ header.stiky-header(ng-controller="NavigationCtrl")
 							a(ui-sref="i18n.docs.dyndnsclient({lang: lang})",translate="menu.docs.dyndnsclient",ng-click="close()")
 						li
 							a(ui-sref="i18n.docs.updateapidetails({lang: lang})",translate="menu.docs.updateapidetails",ng-click="close()")
+						li
+							a(ui-sref="i18n.docs.certbot({lang: lang})",translate="menu.docs.certbot",ng-click="close()")
 				li.has-dropdown(ng-controller="LangChooserCtrl",ng-show="i18n.enabled")
 					a(href="",ng-show="i18n")
 						| Language

--- a/app/scripts/states.js
+++ b/app/scripts/states.js
@@ -139,6 +139,11 @@ angular.module('desecClientApp').config(function ($urlRouterProvider, $stateProv
 			url: "/update-api-details",
 			templateUrl: "views/docs/update-api-details.html"
 		})
+
+		.state('i18n.docs.certbot', {
+			url: "/certbot",
+			templateUrl: "views/docs/certbot.html"
+		})
 	
 	$urlRouterProvider.otherwise('/');
 	

--- a/app/texts/de.json
+++ b/app/texts/de.json
@@ -141,6 +141,7 @@
     },
     "menu": {
         "docs": {
+            "certbot": "Let's Encrypt Zertifikat beantragen",
             "dyndnsclient": "dynDNS Client konfigurieren",
             "headline": "Docs",
             "updateapidetails": "Update-API Details"

--- a/app/texts/en.json
+++ b/app/texts/en.json
@@ -141,6 +141,7 @@
     },
     "menu": {
         "docs": {
+            "certbot": "Obtain Let's Encrypt Certificate",
             "dyndnsclient": "Configure dynDNS Client",
             "headline": "Docs",
             "updateapidetails": "Update API Details"

--- a/app/views/docs/certbot.jade
+++ b/app/views/docs/certbot.jade
@@ -1,0 +1,54 @@
+section.product.page-block
+	.container
+		.row.page-header
+			h2 How to Obtain a Let's Encrypt Certificate for Your dedyn.io Domain
+			span
+				| deSEC supports the DNS challenge protocol to make it easy for you to obtain certificates for
+				| your domain name easily from anywhere. All you need is <a href="https://certbot.eff.org/">certbot</a>,
+				| your credentials and our certbot hook script.
+				| As always, we appreciate your feedback. <a href="mailto:input@desec.io">Shoot us an email!</a>
+		.row
+			.col-md-offset-3.col-md-9
+				p
+					| To obtain a Let's Encrypt Certificate for your dedyn.io domain, follow these steps.
+				
+				h3 Install Certbot
+				p.
+					There are many ways to install certbot, depending on your distribution and preference.
+					Please follow instructions on <a href="https://certbot.eff.org/">certbot.eff.org</a>.
+
+				h3 Install Hook Script
+				p.
+					To authenticate your dedyn.io domain against Let's Encrypt using the DNS challenge mechanism,
+					you will need to update your domain according to instructions provided by Let's Encrypt.
+					<a href="https://github.com/desec-io/certbot-hook">Our hook script</a> automatizes this process for you.
+					To use it, download the <a href="https://raw.githubusercontent.com/desec-io/certbot-hook/master/hook.sh">hook.sh</a>
+					and <a href="https://raw.githubusercontent.com/desec-io/certbot-hook/master/.dedynauth">.dedynauth</a>
+					files and place them into a directory of your choice.
+
+				h3 Set Up Hook Script
+				p.
+					You need to provide your dedyn.io credentials to the hook script,
+					so the script can update your domain information on your behalf.
+					To do so, edit the .dedynauth file to look something like
+				pre.
+					export DEDYN_TOKEN=your token
+					export DEDYN_NAME=yourdomain.dedyn.io
+				
+				h3 Run Certbot
+				p.
+					To obtain your certificate, run certbot in manual mode, setup to use the dedyn hook scripts you just downloaded.
+					For detailed instructions on how to use certbot, please refer to the certbot manual.
+					A typical use of certbot is listed below.
+					Please notice that you need to insert your domain name one more time.
+					(Also, for users not familiar with bash, please note that you need to remove the <code>\</code> if you reformat
+					the command to fit one line.)
+					Depending on how you installed certbot, you may need to replace <code>./certbot-auto</code> with just <code>certbot-auto</code>.
+					Please also note that the hook script may wait up to two minutes to be sure that the challenge was correctly published.
+				pre.
+					./certbot-auto --manual \
+					--text \
+					--preferred-challenges dns \
+					--manual-auth-hook ./hook.sh \
+					-d "YOURDOMAINNAME.dedyn.io" \
+					certonly


### PR DESCRIPTION
This commit adds a guide on how to use Let's Encrypt with dedyn.io to obtain a certificate authenticated using the DNS challenge.

It also adds a hint to get a LE certificate after configuring the domain (i.e. when a record was added to the new dyn domain).

See also desec-io/desec-stack@d9982619682d31bdbdfb58efecfed3ade1a76b67
See also desec-io/certbot-hook@1bd5d7ad5809e755e92626fdf229ee1029016758

ping @peterthomassen 